### PR TITLE
Use querySelector instead of walking the dom

### DIFF
--- a/dist/alpine-turbolinks-adapter.esm.js
+++ b/dist/alpine-turbolinks-adapter.esm.js
@@ -1,12 +1,3 @@
-function walk(el, callback) {
-  if (callback(el) === false) return;
-  let node = el.firstElementChild;
-
-  while (node) {
-    walk(node, callback);
-    node = node.nextElementSibling;
-  }
-}
 function isValidVersion(required, current) {
   const requiredArray = required.split('.');
   const currentArray = current.split('.');
@@ -66,7 +57,7 @@ class Bridge {
 
     document.addEventListener('turbolinks:before-cache', () => {
       this.alpine.pauseMutationObserver = true;
-      walk(document.body, el => {
+      document.body.querySelectorAll('[x-for],[x-if]').forEach(el => {
         if (el.hasAttribute('x-for')) {
           let nextEl = el.nextElementSibling;
 
@@ -82,8 +73,6 @@ class Bridge {
             ifEl.setAttribute('data-alpine-generated-me', true);
           }
         }
-
-        return true;
       });
     });
   }

--- a/dist/alpine-turbolinks-adapter.js
+++ b/dist/alpine-turbolinks-adapter.js
@@ -3,15 +3,6 @@
   factory();
 }((function () { 'use strict';
 
-  function walk(el, callback) {
-    if (callback(el) === false) return;
-    let node = el.firstElementChild;
-
-    while (node) {
-      walk(node, callback);
-      node = node.nextElementSibling;
-    }
-  }
   function isValidVersion(required, current) {
     const requiredArray = required.split('.');
     const currentArray = current.split('.');
@@ -71,7 +62,7 @@
 
       document.addEventListener('turbolinks:before-cache', () => {
         this.alpine.pauseMutationObserver = true;
-        walk(document.body, el => {
+        document.body.querySelectorAll('[x-for],[x-if]').forEach(el => {
           if (el.hasAttribute('x-for')) {
             let nextEl = el.nextElementSibling;
 
@@ -87,8 +78,6 @@
               ifEl.setAttribute('data-alpine-generated-me', true);
             }
           }
-
-          return true;
         });
       });
     }

--- a/src/bridge.js
+++ b/src/bridge.js
@@ -1,4 +1,4 @@
-import { walk, isValidVersion } from './utils'
+import { isValidVersion } from './utils'
 
 export default class Bridge {
   constructor () {
@@ -48,7 +48,7 @@ export default class Bridge {
     document.addEventListener('turbolinks:before-cache', () => {
       this.alpine.pauseMutationObserver = true
 
-      walk(document.body, (el) => {
+      document.body.querySelectorAll('[x-for],[x-if]').forEach((el) => {
         if (el.hasAttribute('x-for')) {
           let nextEl = el.nextElementSibling
           while (nextEl && nextEl.__x_for_key !== 'undefined') {
@@ -62,8 +62,6 @@ export default class Bridge {
             ifEl.setAttribute('data-alpine-generated-me', true)
           }
         }
-
-        return true
       })
     })
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,15 +1,3 @@
-export function walk (el, callback) {
-  if (callback(el) === false) return
-
-  let node = el.firstElementChild
-
-  while (node) {
-    walk(node, callback)
-
-    node = node.nextElementSibling
-  }
-}
-
 export function isValidVersion (required, current) {
   const requiredArray = required.split('.')
   const currentArray = current.split('.')


### PR DESCRIPTION
I have no idea if this is more efficient, but loading the specific elements we want with `querySelectorAll` instead of walking the whole DOM seems like it would be.

I had to build to run the tests so included those files in the PR, but if you want just the changes in `src` let me know and I can fix things up.